### PR TITLE
Ensure proxied info is provided in headers

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -97,6 +97,9 @@ http {
       rewrite ^<%= location %>/?(.*)$ <%= hash['path'] %>/$1 break;
 
       proxy_pass $<%= hash['name'] %>;
+      proxy_set_header Host            $host;
+      proxy_set_header X-Real-IP       $remote_addr;
+      proxy_set_header X-Forwarded-for $remote_addr;
       proxy_ssl_server_name on;
 
       <% if hash['websocket'] %>


### PR DESCRIPTION
When a request is proxied, the original host and IP ought to be passed
along in the HTTP Headers so that the destination host is aware of what
host it is responding as. (This is especially necessary for oauth since
the oauth validation dance requires both the app and the oauth provider
to agree on what the "host" value actually is.)