### PR TITLE
Include forwarded host information

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -97,9 +97,11 @@ http {
       rewrite ^<%= location %>/?(.*)$ <%= hash['path'] %>/$1 break;
 
       proxy_pass $<%= hash['name'] %>;
-      proxy_set_header Host            $host;
-      proxy_set_header X-Real-IP       $remote_addr;
-      proxy_set_header X-Forwarded-for $remote_addr;
+      proxy_set_header Host             $host;
+      proxy_set_header X-Real-IP        $remote_addr;
+      proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Host $host;
+
       proxy_ssl_server_name on;
 
       <% if hash['websocket'] %>


### PR DESCRIPTION
Rails needs to be aware of the host that it's operating "behind" (ie, the proxy host),
such that any redirects or absolute URL formulations preserve the full host as seen by the end user.