### PR TITLE
Remove Host header

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -97,8 +97,6 @@ http {
       rewrite ^<%= location %>/?(.*)$ <%= hash['path'] %>/$1 break;
 
       proxy_pass $<%= hash['name'] %>;
-      proxy_set_header Host             $host;
-      proxy_set_header X-Real-IP        $remote_addr;
       proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Host $host;
 


### PR DESCRIPTION
Adding the Host header seemed to cause an infinite loop of redirects.
X-Real-IP is basically a lie as well, since $remote_addr is actually the
IP of heroku load balancers (or whatever heroku hardware last forwarded
the request to nginx). It's not actually necessary anyway.